### PR TITLE
removes unneeded package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "serve": "cross-env NODE_ENV=development npm run build && cross-env NODE_ENV=development npm-run-all -p start serve:client",
+    "serve": "cross-env NODE_ENV=development npm run build && cross-env NODE_ENV=development npm run serve:client",
     "serve:client": "vue-cli-service serve",
     "build": "npm run build:server -- --silent && npm run build:client -- --no-clean --silent",
     "build:client": "vue-cli-service build",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@vue/cli-service": "^3.4.0",
     "cross-env": "^5.2.0",
     "lodash.merge": "^4.6.1",
-    "npm-run-all": "^4.1.5",
     "vue-template-compiler": "2.5.17",
     "webpack-node-externals": "^1.7.2"
   },


### PR DESCRIPTION
This commit removes:
- `start` task from `serve` because `serve:client` do the same thing
- `npm-run-all` package because is not needed anymore

I hope it helps.