### PR TITLE
Do not extract css in the server build

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -20,7 +20,7 @@ module.exports = {
     }
   },
   css: {
-    extract: process.env.NODE_ENV === 'production'
+    extract: process.env.NODE_ENV === 'production' && !TARGET_NODE
   },
   configureWebpack: () => ({
     entry: `./src/entry-${target}`,


### PR DESCRIPTION
otherwise you get "document is not defined" errors in the production build.

I am not completely sure if my solution is correct, but at least I got the project working this way.

To reproduce the error, just build an image from the Dockerfile and run it, once you access localhost:8080 you get "500 Internal Server Error" with lots of "document is not defined" errors